### PR TITLE
Adds 'apply all changes' button

### DIFF
--- a/pythermostat/pythermostat/control_panel.py
+++ b/pythermostat/pythermostat/control_panel.py
@@ -5,8 +5,9 @@ import logging
 import argparse
 import importlib.resources
 import json
+from functools import partial
 from PyQt6 import QtWidgets, QtGui, uic
-from PyQt6.QtCore import pyqtSlot
+from PyQt6.QtCore import Qt, pyqtSlot
 import qasync
 from qasync import asyncSlot, asyncClose
 from pythermostat.autotune import PIDAutotuneState
@@ -70,6 +71,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self._on_pid_autotune_state_changed
         )
 
+        self.apply_all_settings_btns = [None for i in range(self.NUM_CHANNELS)]
+
         # Handlers for disconnections
         async def autotune_disconnect():
             for ch in range(self.NUM_CHANNELS):
@@ -98,6 +101,29 @@ class MainWindow(QtWidgets.QMainWindow):
             [self.ch0_tree, self.ch1_tree],
             get_ctrl_panel_config(args),
         )
+
+        for ch in range(self.NUM_CHANNELS):
+            vertical_layouts = "verticalLayout"+["_2", ""][ch]
+            palette = QtGui.QPalette()
+            brush = QtGui.QBrush(QtGui.QColor(246, 211, 45))
+
+            brush.setStyle(Qt.BrushStyle.SolidPattern)
+            palette.setBrush(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Button, brush)
+            brush = QtGui.QBrush(QtGui.QColor(246, 211, 45))
+            brush.setStyle(Qt.BrushStyle.SolidPattern)
+            palette.setBrush(QtGui.QPalette.ColorGroup.Inactive, QtGui.QPalette.ColorRole.Button, brush)
+            brush = QtGui.QBrush(QtGui.QColor(246, 211, 45))
+            brush.setStyle(Qt.BrushStyle.SolidPattern)
+            palette.setBrush(QtGui.QPalette.ColorGroup.Disabled, QtGui.QPalette.ColorRole.Button, brush)
+
+            self.apply_all_settings_btns[ch] = QtWidgets.QPushButton(f"Apply Changes to Channel {ch}", parent=getattr(self, f"ch{ch}_tab")) #what even is this bruh TT_TT
+            getattr(self, vertical_layouts).addWidget(self.apply_all_settings_btns[ch])
+
+            self.apply_all_settings_btns[ch].setPalette(palette)
+            self.apply_all_settings_btns[ch].setVisible(False)
+
+            self._ctrl_panel_view.sigQueuedChangedSetting.connect(self._show_apply_all_settings_btn)
+            self.apply_all_settings_btns[ch].clicked.connect(partial(self._apply_all_settings_btn_clicked, ch))
 
         # Graphs
         self._channel_graphs = LiveDataPlotter(
@@ -139,6 +165,29 @@ class MainWindow(QtWidgets.QMainWindow):
             self._thermostat.connection_state = ThermostatConnectionState.DISCONNECTED
         except:
             pass
+
+    @pyqtSlot(int)
+    def _show_apply_all_settings_btn(self, ch):
+        self.apply_all_settings_btns[ch].setVisible(True)
+
+    @asyncSlot(bool)
+    async def _apply_all_settings_btn_clicked(self, ch, clicked):
+        self._queued_changes = self._ctrl_panel_view.queued_changes
+
+        for param in self._queued_changes:
+            if self._queued_changes[param][0] != ch:
+                continue
+            data = self._queued_changes[param][1]
+            thermostat_param = self._queued_changes[param][2]
+            if param.opts.get("suffix", None) == "mA":
+                data /= 1000
+            if not "pid_autotune" in param.opts:
+                await self._ctrl_panel_view.apply_setting(param, ch, data, thermostat_param)
+            else:
+                self._ctrl_panel_view.autotuners.set_params(param.opts["pid_autotune"], ch, param)
+            
+        self._ctrl_panel_view.flush_queued_settings()
+        self.apply_all_settings_btns[ch].setVisible(False)
 
     @pyqtSlot(ThermostatConnectionState)
     def _on_connection_state_changed(self, state):

--- a/pythermostat/pythermostat/gui/view/ctrl_panel.py
+++ b/pythermostat/pythermostat/gui/view/ctrl_panel.py
@@ -46,6 +46,9 @@ registerParameterType("mutex", MutexParameter)
 
 
 class CtrlPanel(QObject):
+    
+    sigQueuedChangedSetting = pyqtSignal(int)
+    
     def __init__(
         self,
         thermostat,
@@ -62,6 +65,8 @@ class CtrlPanel(QObject):
         self.info_box = info_box
         self.trees_ui = trees_ui
         self.NUM_CHANNELS = len(trees_ui)
+        self._queued_changes = {}
+        self._settings_visual_update = set()
 
         self.THERMOSTAT_PARAMETERS = [param_tree for i in range(self.NUM_CHANNELS)]
 
@@ -82,7 +87,7 @@ class CtrlPanel(QObject):
             tree.setHeaderHidden(True)
             tree.setParameters(self.params[i], showTop=False)
             self.params[i].setValue = self._setValue
-            self.params[i].sigTreeStateChanged.connect(self.send_command)
+            self.params[i].sigTreeStateChanged.connect(self._queue_changes)
 
             self.params[i].child("save").sigActivated.connect(
                 partial(self.save_settings, i)
@@ -127,67 +132,95 @@ class CtrlPanel(QObject):
 
         return self.opts["value"]
 
+    @property
+    def queued_changes(self):
+        return self._queued_changes
+
     def change_params_title(self, channel, path, title):
         self.params[channel].child(*path).setOpts(title=title)
 
     @asyncSlot(object, object)
-    async def send_command(self, param, changes):
+    async def _queue_changes(self, param, changes):
         """Translates parameter tree changes into thermostat set_param calls"""
         ch = param.channel
 
-        for inner_param, change, data in changes:
-            if change == "value":
-                new_value = data
-                if "thermostat:set_param" in inner_param.opts:
-                    if inner_param.opts.get("suffix", None) == "mA":
-                        new_value /= 1000  # Given in mA
+        for inner_param, change_type, data in changes: 
+            if change_type != "value":
+                continue
+            
+            thermostat_param = inner_param.opts["thermostat:set_param"]
+            if inner_param.opts["type"] in ["mutex", "list"]:
+                match inner_param.name(), data:
+                    case "rate", None:
+                        thermostat_param = thermostat_param.copy()
+                        thermostat_param["field"] = "off"
+                        data = ""
+                    case "control_method", "constant_current":
+                        thermostat_param = thermostat_param.copy()
+                        thermostat_param["field"] = "i_set"
+                        data = inner_param.child("i_set").value()
+                    case "control_method", "temperature_pid":
+                        data = ""
 
-                    thermostat_param = inner_param.opts["thermostat:set_param"]
+            if not inner_param.opts.get("excludeQueue", False):
+                self._queued_changes[inner_param] = (ch, data, thermostat_param) 
+                self.sigQueuedChangedSetting.emit(ch)
+                continue
 
-                    # Handle thermostat command irregularities
-                    match inner_param.name(), new_value:
-                        case "rate", None:
-                            thermostat_param = thermostat_param.copy()
-                            thermostat_param["field"] = "off"
-                            new_value = ""
-                        case "control_method", "constant_current":
-                            return
-                        case "control_method", "temperature_pid":
-                            new_value = ""
+            await self.apply_setting(inner_param, ch, data, thermostat_param)
 
-                    inner_param.setOpts(lock=True)
-                    await self.thermostat.set_param(
-                        channel=ch, value=new_value, **thermostat_param
-                    )
-                    inner_param.setOpts(lock=False)
+    async def apply_setting(self, param, channel, data, thermostat_param):
+        param.setOpts(lock=True)
+        await self.thermostat.set_param(channel=channel, value=data, **thermostat_param)
+        param.setOpts(lock=False)
 
-                if "pid_autotune" in inner_param.opts:
-                    auto_tuner_param = inner_param.opts["pid_autotune"]
-                    self.autotuners.set_params(auto_tuner_param, ch, new_value)
+    def flush_queued_settings(self):
+        self._queued_changes.clear()
+    
+    def _is_in_queued_changes(self, setting, ch):
+        for param, cont in self._queued_changes.items():
+            _ch,_data,_thermo_param = cont
+            if ch == _ch and setting == param.opts["name"]:
+                return True
+        return False
+
+    def _handle_queued_settings(self, ch, data, path):
+        name = path[-1]
+        setting_param = self.params[ch].child(*path)
+        is_queued_setting = self._is_in_queued_changes(name, ch)
+        is_in_setting_visual_update = (name, ch) in self._settings_visual_update
+        match is_queued_setting, is_in_setting_visual_update:
+            case True, False:
+                self._settings_visual_update.add( (name, ch) )
+                setting_param.setOpts(title=setting_param.opts["title"] + " (*)")
+                for item in setting_param.items:
+                    font = item.font(0); font.setBold(True); font.setUnderline(True)
+                    item.setFont(0, font)
+            case True, _:
+                for item in setting_param.items:
+                    item.setToolTip(1, f"Current value: {data}")
+            case False, True:
+                setting_param.setValue(data)
+                setting_param.setOpts(title=(setting_param.opts["title"])[0:-3])
+                for item in setting_param.items:
+                    font = item.font(0); font.setBold(False); font.setUnderline(False)
+                    item.setFont(0, font)
+                self._settings_visual_update.discard( (name, ch) )
+            case False, False:
+                setting_param.setValue(data)
+                for item in setting_param.items:
+                    item.setToolTip(1, f"Current value: {data}")
 
     @pyqtSlot(list)
     def update_pid(self, pid_settings):
         for settings in pid_settings:
             channel = settings["channel"]
             with QSignalBlocker(self.params[channel]):
-                self.params[channel].child("pid", "kp").setValue(
-                    settings["parameters"]["kp"]
-                )
-                self.params[channel].child("pid", "ki").setValue(
-                    settings["parameters"]["ki"]
-                )
-                self.params[channel].child("pid", "kd").setValue(
-                    settings["parameters"]["kd"]
-                )
-                self.params[channel].child(
-                    "pid", "pid_output_clamping", "output_min"
-                ).setValue(settings["parameters"]["output_min"] * 1000)
-                self.params[channel].child(
-                    "pid", "pid_output_clamping", "output_max"
-                ).setValue(settings["parameters"]["output_max"] * 1000)
-                self.params[channel].child(
-                    "output", "control_method", "target"
-                ).setValue(settings["target"])
+                for name in ["kp", "ki", "kd"]:
+                    self._handle_queued_settings(channel, settings["parameters"][name], ("pid", name))
+                self._handle_queued_settings(channel, settings["parameters"]["output_min"]*1000, ("pid", "pid_output_clamping", "output_min"))
+                self._handle_queued_settings(channel, settings["parameters"]["output_max"]*1000, ("pid", "pid_output_clamping", "output_min"))
+                self._handle_queued_settings(channel, settings["target"], ("output", "control_method", "target"))
 
     @pyqtSlot(list)
     def update_report(self, report_data):
@@ -197,9 +230,7 @@ class CtrlPanel(QObject):
                 self.params[channel].child("output", "control_method").setValue(
                     "temperature_pid" if settings["pid_engaged"] else "constant_current"
                 )
-                self.params[channel].child(
-                    "output", "control_method", "i_set"
-                ).setValue(settings["i_set"] * 1000)
+                self._handle_queued_settings(channel, settings["i_set"]*1000, ("output", "control_method", "i_set"))
                 if settings["temperature"] is not None:
                     self.params[channel].child("readings", "temperature").setValue(
                         settings["temperature"]
@@ -214,39 +245,25 @@ class CtrlPanel(QObject):
         for sh_param in sh_data:
             channel = sh_param["channel"]
             with QSignalBlocker(self.params[channel]):
-                self.params[channel].child("thermistor", "t0").setValue(
-                    sh_param["params"]["t0"] - 273.15
-                )
-                self.params[channel].child("thermistor", "r0").setValue(
-                    sh_param["params"]["r0"]
-                )
-                self.params[channel].child("thermistor", "b").setValue(
-                    sh_param["params"]["b"]
-                )
+                self._handle_queued_settings(channel, sh_param["params"]["t0"]-273.15, ("thermistor", "t0"))
+                self._handle_queued_settings(channel, sh_param["params"]["r0"], ("thermistor", "r0"))
+                self._handle_queued_settings(channel, sh_param["params"]["b"], ("thermistor", "b"))
 
     @pyqtSlot(list)
     def update_output(self, output_data):
         for output_params in output_data:
             channel = output_params["channel"]
             with QSignalBlocker(self.params[channel]):
-                self.params[channel].child("output", "limits", "max_v").setValue(
-                    output_params["max_v"]
-                )
-                self.params[channel].child("output", "limits", "max_i_pos").setValue(
-                    output_params["max_i_pos"] * 1000
-                )
-                self.params[channel].child("output", "limits", "max_i_neg").setValue(
-                    output_params["max_i_neg"] * 1000
-                )
+                self._handle_queued_settings(channel, output_params["max_v"], ("output", "limits", "max_v"))
+                self._handle_queued_settings(channel, output_params["max_i_pos"]*1000, ("output", "limits", "max_i_pos"))
+                self._handle_queued_settings(channel, output_params["max_i_neg"]*1000, ("output", "limits", "max_i_neg"))
 
     @pyqtSlot(list)
     def update_postfilter(self, postfilter_data):
         for postfilter_params in postfilter_data:
             channel = postfilter_params["channel"]
             with QSignalBlocker(self.params[channel]):
-                self.params[channel].child("thermistor", "rate").setValue(
-                    postfilter_params["rate"]
-                )
+                self._handle_queued_settings(channel, postfilter_params["rate"], ("thermistor", "rate"))
 
     def update_pid_autotune(self, ch, state):
         match state:

--- a/pythermostat/pythermostat/gui/view/param_tree.json
+++ b/pythermostat/pythermostat/gui/view/param_tree.json
@@ -32,6 +32,7 @@
                "name": "control_method",
                "title": "Control Method",
                "type": "mutex",
+               "excludeQueue": true,
                "limits": {
                   "Constant Current": "constant_current",
                   "Temperature PID": "temperature_pid"
@@ -46,13 +47,14 @@
                      "name": "i_set",
                      "title": "Set Current",
                      "type": "float",
+                     "excludeQueue": false,
                      "value": 0,
                      "step": 100,
                      "limits": [
                         -2000,
                         2000
                      ],
-                     "triggerOnShow": true,
+                     "triggerOnShow": false,
                      "decimals": 6,
                      "suffix": "mA",
                      "compactHeight": false,
@@ -66,6 +68,7 @@
                      "name": "target",
                      "title": "Set Temperature",
                      "type": "float",
+                     "excludeQueue": false,
                      "value": 25,
                      "step": 0.1,
                      "limits": [


### PR DESCRIPTION
Show an 'apply all changes' button at the bottom of control panel when values are changed in the parameter tree, and make the affected changes' fonts underlined and bold until the 'apply all changes' button is clicked. A tool tip also appears on hover, showing the currently applied value of that parameter. 

Automatic parameter updates may lead to accidental parameter updates the user. This pr allows the user to easily and safely double check and confirm their changes.
<img width="1257" height="740" alt="image" src="https://github.com/user-attachments/assets/036ddc14-814d-4809-a27a-ec494c4f2f9b" />
