### PR TITLE
Move saving/loading settings from param_tree to a popup menu

### DIFF
--- a/pythermostat/pythermostat/control_panel.py
+++ b/pythermostat/pythermostat/control_panel.py
@@ -5,8 +5,9 @@ import logging
 import argparse
 import importlib.resources
 import json
+from functools import partial
 from PyQt6 import QtWidgets, QtGui, uic
-from PyQt6.QtCore import pyqtSlot
+from PyQt6.QtCore import Qt, pyqtSlot, QPoint
 import qasync
 from qasync import asyncSlot, asyncClose
 from pythermostat.autotune import PIDAutotuneState
@@ -14,7 +15,7 @@ from pythermostat.gui.model.thermostat import Thermostat, ThermostatConnectionSt
 from pythermostat.gui.model.pid_autotuner import PIDAutoTuner
 from pythermostat.gui.view.ctrl_panel import CtrlPanel
 from pythermostat.gui.view.info_box import InfoBox
-from pythermostat.gui.view.menus import PlotOptionsMenu, ThermostatSettingsMenu, ConnectionDetailsMenu
+from pythermostat.gui.view.menus import PlotOptionsMenu, ThermostatSettingsMenu, ConnectionDetailsMenu, SettingsMenu
 from pythermostat.gui.view.live_plot_view import LiveDataPlotter
 from pythermostat.gui.view.zero_limits_warning_view import ZeroLimitsWarningView
 
@@ -99,6 +100,16 @@ class MainWindow(QtWidgets.QMainWindow):
             get_ctrl_panel_config(args),
         )
 
+        # Save/load settings menu
+        self._settings_menu = SettingsMenu(self._thermostat, self._info_box)
+
+        self.tabWidget.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.tabWidget.customContextMenuRequested.connect(self.openSettingsContextMenu)
+
+        for ch in range(self.NUM_CHANNELS):
+            getattr(self, f"ch{ch}_tree").setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+            getattr(self, f"ch{ch}_tree").customContextMenuRequested.connect(self.openSettingsContextMenu)
+
         # Graphs
         self._channel_graphs = LiveDataPlotter(
             self._thermostat,
@@ -139,6 +150,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self._thermostat.connection_state = ThermostatConnectionState.DISCONNECTED
         except:
             pass
+
+    @pyqtSlot(QPoint)
+    def openSettingsContextMenu(self, pos):
+        self._settings_menu.update_menu(self.tabWidget.currentIndex())
+        action = self._settings_menu.exec(self.sender().mapToGlobal(pos))
 
     @pyqtSlot(ThermostatConnectionState)
     def _on_connection_state_changed(self, state):

--- a/pythermostat/pythermostat/gui/view/ctrl_panel.py
+++ b/pythermostat/pythermostat/gui/view/ctrl_panel.py
@@ -84,12 +84,6 @@ class CtrlPanel(QObject):
             self.params[i].setValue = self._setValue
             self.params[i].sigTreeStateChanged.connect(self.send_command)
 
-            self.params[i].child("save").sigActivated.connect(
-                partial(self.save_settings, i)
-            )
-            self.params[i].child("load").sigActivated.connect(
-                partial(self.load_settings, i)
-            )
             self.params[i].child("pid", "pid_autotune", "run_pid").sigActivated.connect(
                 partial(self.pid_auto_tune_request, i)
             )
@@ -268,25 +262,6 @@ class CtrlPanel(QObject):
                     "PID Autotune Failed",
                     f"Channel {ch} PID Autotune has failed.",
                 )
-
-    @asyncSlot(int)
-    async def load_settings(self, ch):
-        await self.thermostat.load_cfg(ch)
-
-        self.info_box.display_info_box(
-            f"Channel {ch} settings loaded",
-            f"Channel {ch} settings has been loaded from flash.",
-        )
-
-    @asyncSlot(int)
-    async def save_settings(self, ch):
-        await self.thermostat.save_cfg(ch)
-
-        self.info_box.display_info_box(
-            f"Channel {ch} settings saved",
-            f"Channel {ch} settings has been saved to flash.\n"
-            "It will be loaded on Thermostat reset, or when settings are explicitly loaded.",
-        )
 
     @asyncSlot()
     async def pid_auto_tune_request(self, ch=0):

--- a/pythermostat/pythermostat/gui/view/menus.py
+++ b/pythermostat/pythermostat/gui/view/menus.py
@@ -3,6 +3,55 @@ from PyQt6.QtCore import pyqtSlot, QSignalBlocker
 from qasync import asyncSlot
 from pythermostat.gui.model.thermostat import ThermostatConnectionState
 from pythermostat.gui.view.net_settings_input_diag import NetSettingsInputDiag
+from functools import partial
+
+
+class SettingsMenu(QtWidgets.QMenu):
+    def __init__(self, thermostat, info_box):
+        super().__init__()
+        self._thermostat = thermostat
+        self._info_box = info_box
+
+    def update_menu(self, current_tab):
+        self._current_tab = current_tab
+        self._setup_menu_items()
+
+    def _setup_menu_items(self):
+        self.clear()
+
+        self._save_cur_cfg = QtGui.QAction(f"Save channel {self._current_tab} settings", self)
+        self._save_all_cfg = QtGui.QAction("Save all settings", self)
+        self._load_cur_cfg = QtGui.QAction(f"Load channel {self._current_tab} settings", self)
+        self._load_all_cfg = QtGui.QAction("Load all settings", self)                       
+
+        self._save_cur_cfg.triggered.connect(partial(self._save_settings, self._current_tab))
+        self._save_all_cfg.triggered.connect(partial(self._save_settings, ""))
+        self._load_cur_cfg.triggered.connect(partial(self._load_settings, self._current_tab))
+        self._load_all_cfg.triggered.connect(partial(self._load_settings, ""))
+
+        self.addAction(self._save_cur_cfg)
+        self.addAction(self._save_all_cfg)
+        self.addAction(self._load_cur_cfg)
+        self.addAction(self._load_all_cfg)
+
+    @asyncSlot(int)
+    async def _load_settings(self, ch, state):
+        await self._thermostat.load_cfg(ch)
+
+        self._info_box.display_info_box(
+            f"Channel {ch} settings loaded",
+            f"Channel {ch} settings has been loaded from flash.",
+        )
+
+    @asyncSlot(int)
+    async def _save_settings(self, ch, state):
+        await self._thermostat.save_cfg(ch)
+
+        self._info_box.display_info_box(
+            f"Channel {ch} settings saved",
+            f"Channel {ch} settings has been saved to flash.\n"
+            "It will be loaded on Thermostat reset, or when settings are explicitly loaded.",
+        )
 
 
 class ConnectionDetailsMenu(QtWidgets.QMenu):

--- a/pythermostat/pythermostat/gui/view/param_tree.json
+++ b/pythermostat/pythermostat/gui/view/param_tree.json
@@ -374,18 +374,6 @@
                ]
             }
          ]
-      },
-      {
-         "name": "save",
-         "title": "Save to flash",
-         "type": "action",
-         "tip": "Save settings to thermostat, applies on reset"
-      },
-      {
-         "name": "load",
-         "title": "Load from flash",
-         "type": "action",
-         "tip": "Load settings from flash"
       }
    ]
 }


### PR DESCRIPTION
Move the saving and loading settings from the bottom of the parameter tree to a popup menu that appears on right click. 
PR makes it more convenient to save and load settings, and makes the param tree ui more coherent (no random buttons) 