### PR TITLE
Add set pid setpoint to current temp popup menu

### DIFF
--- a/pythermostat/pythermostat/gui/view/ctrl_panel.py
+++ b/pythermostat/pythermostat/gui/view/ctrl_panel.py
@@ -1,4 +1,7 @@
 from functools import partial
+from types import MethodType
+from PyQt6 import QtWidgets
+from PyQt6.QtGui import QAction
 from PyQt6.QtCore import pyqtSignal, QObject, QSignalBlocker, pyqtSlot
 import pyqtgraph.parametertree.parameterTypes as pTypes
 from pyqtgraph.parametertree import (
@@ -78,11 +81,35 @@ class CtrlPanel(QObject):
         for i, param in enumerate(self.params):
             param.channel = i
 
+        def _setTargetToMeasured(spinbox_self):
+            spinbox_self.setValue(self.params[spinbox_self._channel].child("readings", "temperature").value())
+        
+        def _targetContextMenuEvent(self, ev):
+            self._contextMenu = QtWidgets.QMenu()
+
+            self._contextMenu.addAction(QAction("Set To Measurement", self, triggered=self.setTargetToMeasured))
+            self._contextMenu.addSeparator()
+            
+            self._stdMenu = QtWidgets.QLineEdit(self).createStandardContextMenu()
+            self._contextMenu.addActions(self._stdMenu.actions())
+
+            self._contextMenu.addSeparator()
+            self._contextMenu.addAction(QAction("Step Up", self, triggered=self.stepUp))
+            self._contextMenu.addAction(QAction("Step Down", self, triggered=self.stepDown))
+
+            self._contextMenu.popup(ev.globalPos())
+
         for i, tree in enumerate(self.trees_ui):
             tree.setHeaderHidden(True)
             tree.setParameters(self.params[i], showTop=False)
             self.params[i].setValue = self._setValue
             self.params[i].sigTreeStateChanged.connect(self.send_command)
+
+            for item in self.params[i].child("output", "control_method", "target").items:
+                setattr(item.widget, "_param", item.param)
+                setattr(item.widget, "_channel", i)
+                item.widget.setTargetToMeasured = MethodType(_setTargetToMeasured, item.widget)
+                item.widget.contextMenuEvent = MethodType(_targetContextMenuEvent, item.widget)
 
             self.params[i].child("save").sigActivated.connect(
                 partial(self.save_settings, i)

--- a/pythermostat/pythermostat/gui/view/ctrl_panel.py
+++ b/pythermostat/pythermostat/gui/view/ctrl_panel.py
@@ -81,21 +81,23 @@ class CtrlPanel(QObject):
         for i, param in enumerate(self.params):
             param.channel = i
 
-        def _setTargetToMeasured(spinbox_self):
-            spinbox_self.setValue(self.params[spinbox_self._channel].child("readings", "temperature").value())
-        
         def _targetContextMenuEvent(self, ev):
             self._contextMenu = QtWidgets.QMenu()
 
-            self._contextMenu.addAction(QAction("Set To Measurement", self, triggered=self.setTargetToMeasured))
+            self._contextMenu.addAction(QAction("Set to Measured Temperature", self, triggered=lambda: self.setValue(self._temp.value())))
             self._contextMenu.addSeparator()
             
-            self._stdMenu = QtWidgets.QLineEdit(self).createStandardContextMenu()
+            self._stdMenu = QtWidgets.QLabel(self).createStandardContextMenu()
             self._contextMenu.addActions(self._stdMenu.actions())
 
+            self._contextMenu.popup(ev.globalPos())
+
+        def _tempContextMenuEvent(self, ev):
+            self._contextMenu = QtWidgets.QMenu()
+            self._contextMenu.addAction(QAction("Set Setpoint as Measurement", self, triggered=lambda: self._target.setValue(self._temp.value())))
             self._contextMenu.addSeparator()
-            self._contextMenu.addAction(QAction("Step Up", self, triggered=self.stepUp))
-            self._contextMenu.addAction(QAction("Step Down", self, triggered=self.stepDown))
+
+            self._contextMenu.addAction(QAction("&Copy", self, triggered=lambda: QtWidgets.QApplication.clipboard().setText(str(self._temp.value()))))
 
             self._contextMenu.popup(ev.globalPos())
 
@@ -105,12 +107,17 @@ class CtrlPanel(QObject):
             self.params[i].setValue = self._setValue
             self.params[i].sigTreeStateChanged.connect(self.send_command)
 
-            for item in self.params[i].child("output", "control_method", "target").items:
-                setattr(item.widget, "_param", item.param)
-                setattr(item.widget, "_channel", i)
-                item.widget.setTargetToMeasured = MethodType(_setTargetToMeasured, item.widget)
-                item.widget.contextMenuEvent = MethodType(_targetContextMenuEvent, item.widget)
+            for target_item in self.params[i].child("output", "control_method", "target").items:
+                setattr(target_item.widget, "_temp", self.params[i].child("readings", "temperature"))
+                setattr(target_item.widget, "_channel", i)
+                target_item.widget.contextMenuEvent = MethodType(_targetContextMenuEvent, target_item.widget)
 
+                for temp_item in self.params[i].child("readings", "temperature").items:
+                    setattr(temp_item.displayLabel, "_temp", self.params[i].child("readings", "temperature"))
+                    setattr(temp_item.displayLabel, "_target", target_item.widget)
+                    setattr(temp_item.displayLabel, "_channel", i)
+                    temp_item.displayLabel.contextMenuEvent = MethodType(_tempContextMenuEvent, temp_item.displayLabel)
+            
             self.params[i].child("save").sigActivated.connect(
                 partial(self.save_settings, i)
             )


### PR DESCRIPTION
A popup menu that sets the PID temperature setpoint to the currently measured temperature
Makes it more convenient to set pid setpoint
<img width="1257" height="740" alt="image" src="https://github.com/user-attachments/assets/9944fd20-aeea-4bfa-b687-aea1b0f4f80f" />
